### PR TITLE
fix  init_state bug

### DIFF
--- a/deepSI/fit_systems/ss_linear.py
+++ b/deepSI/fit_systems/ss_linear.py
@@ -353,7 +353,7 @@ class SS_linear(System_ss, System_fittable):
         y = sys_data.y
         u = sys_data.u
 
-        self.x = Cy@y[:k0][::-1].flat + Cu@u[:k0][::-1].flat
+        self.x = Cy@y[:k0][::-1].reshape(-1, 1) + Cu@u[:k0][::-1].reshape(-1, 1)
         return k0
 
 class SS_linear_CT(SS_linear):


### PR DESCRIPTION
This merge request addresses an issue with the OLS formula in the linear state space class.

The problematic line uses the numpy attribute flat, which is inappropriate in this context:
https://github.com/GerbenBeintema/deepSI/blob/b393df4474eb6af64e3585fe90647f8d15b2a22c/deepSI/fit_systems/ss_linear.py#L356

Below is a script to demonstrate the issue:

```python
system = deepSI.fit_systems.SS_linear(A=np.array([[0.9,0.1],[0.0,0.7]]), B=np.array([[1,0.0],[0.0, 2]]),
                                      C=np.array([[1.0,2.]]), k0=3)


u0 = np.array([[1.0,2.0]]).T
u1 = np.array([[0.2,0.0]]).T
u2 = np.array([[-2.0,1.]]).T

system.x = np.array([[1.0],[2.0]])
y0 =system.measure_act(u0)
y1 =system.measure_act(u1)
y2 =system.measure_act(u2)

dataset =  deepSI.System_data(y=np.stack([y0, y1, y2]), u=np.concatenate([u0,u1, u2], axis=1).T, normed=True)
system.init_state(dataset)
print(system.measure_act(u2).shape)
print(system.measure_act(u2).shape)
```
The expected output is:
```
(1,)
(1,)
```
However, the current output is:
```
()
(2,)
```

This inconsistency arises because the OLS produces a state of shape (n_x, ) instead of (n_x, 1). When applying the f function, as seen [here](https://github.com/GerbenBeintema/deepSI/blob/b393df4474eb6af64e3585fe90647f8d15b2a22c/deepSI/fit_systems/ss_linear.py#L303), numpy produces a state x of shape (n_x, n_x) due to broadcasting, rather than actual matrix multiplication. The state is now  in an incorrect shape.
 
 To rectify this, I've replaced the inappropriate use of flat with .reshape(-1, 1), ensuring consistent 2D shaping.

Please let me know if there are any questions or further discussions required.

Thank you for considering this fix.
Best regards,
 
 
 
 
