### PR TITLE
Fix initialization of  SS_linear

### DIFF
--- a/deepSI/fit_systems/ss_linear.py
+++ b/deepSI/fit_systems/ss_linear.py
@@ -252,17 +252,18 @@ def SS_lsim_process_form(A, B, C, D, u, x0=None):
 
 class SS_linear(System_ss, System_fittable):
     def __init__(self,seed=None,A=None,B=None,C=None,D=None, nx=2, feedthrough=False, k0=None):
-        self.ny = None
-        self.nu = None
+        ny = None
+        nu = None
         self.A, self.B, self.C, self.D = A, B, C, D
         if A is not None:
             self.fitted = True
             nx = A.shape[0]
-            self.ny = C.shape[0] if C.shape[0]!=1 else None
-            self.nu = B.shape[1]
+            ny = C.shape[0] if C.shape[0]!=1 else None
+            nu = B.shape[1]
+
         self.feedthrough = feedthrough or (D is not None and np.sum(np.array(D)**2)!=0) #non-zero D
         self.k0 = k0
-        super(SS_linear, self).__init__(nx=nx)
+        super(SS_linear, self).__init__(nx=nx, ny=ny, nu=nu)
 
     def _fit(self,sys_data,SS_A_stability=False,SS_f=20):
         assert isinstance(sys_data,System_data), 'Using multiple datasets to estimate ss_linear is not yet implemented'


### PR DESCRIPTION
The actual version of deepSI provide a bad behavior with the SS_linear constructor.

This is a little example to hightight the problem:

```python
import deepSI as  deepSI
import numpy as np 

system = deepSI.fit_systems.SS_linear(A=np.array([[0.9,0.1],[0.0,0.7]]), B=np.array([[1,0.0],[0.0, 2]]),
                                      C=np.array([[1.0,2.],[0.0,1.0]]), k0=3)


print("ny : ", system.ny)
print("nu : ", system.nu)
```

Actual output: 
```python
ny :  None
nu :  None
```


The problem here is that even if we initialize SS_linear.ny and SS_linear.nu line [262](https://github.com/GerbenBeintema/deepSI/blob/2b240fcc83af110deab52fdd93c063b816cd09e3/deepSI/fit_systems/ss_linear.py#L262), an override is done with the `System_ss` constructor that uses it's default kwargs parameters (see [470](https://github.com/GerbenBeintema/deepSI/blob/2b240fcc83af110deab52fdd93c063b816cd09e3/deepSI/systems/system.py#L470))

I just pass the computed nu and ny to the constructor of `System_ss` to fix the problem.


New output with the fix:
```python
ny :  2
nu :  2
```

Thank you for considering this fix.
Best regards,
 

